### PR TITLE
Faction selection

### DIFF
--- a/bulma.css
+++ b/bulma.css
@@ -737,9 +737,6 @@ a.box:active {
   border: 1px solid #d3d6db;
   border-radius: 3px;
   color: #222324;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 14px;
   height: 32px;
@@ -748,8 +745,6 @@ a.box:active {
       -ms-flex-pack: start;
           justify-content: flex-start;
   line-height: 24px;
-  padding-left: 8px;
-  padding-right: 8px;
   position: relative;
   vertical-align: top;
   -webkit-box-pack: center;
@@ -760,6 +755,7 @@ a.box:active {
   padding-right: 10px;
   text-align: center;
   white-space: nowrap;
+  margin-left: 3px;
 }
 
 .button:hover {
@@ -771,26 +767,31 @@ a.box:active {
   outline: none;
 }
 
-.button[disabled], .button.is-disabled {
+.button[disabled], 
+.button.is-disabled {
   background-color: #f5f7fa;
   border-color: #d3d6db;
   cursor: not-allowed;
   pointer-events: none;
 }
 
-.button[disabled]::-moz-placeholder, .button.is-disabled::-moz-placeholder {
+.button[disabled]::-moz-placeholder, 
+.button.is-disabled::-moz-placeholder {
   color: rgba(34, 35, 36, 0.3);
 }
 
-.button[disabled]::-webkit-input-placeholder, .button.is-disabled::-webkit-input-placeholder {
+.button[disabled]::-webkit-input-placeholder, 
+.button.is-disabled::-webkit-input-placeholder {
   color: rgba(34, 35, 36, 0.3);
 }
 
-.button[disabled]:-moz-placeholder, .button.is-disabled:-moz-placeholder {
+.button[disabled]:-moz-placeholder, 
+.button.is-disabled:-moz-placeholder {
   color: rgba(34, 35, 36, 0.3);
 }
 
-.button[disabled]:-ms-input-placeholder, .button.is-disabled:-ms-input-placeholder {
+.button[disabled]:-ms-input-placeholder, 
+.button.is-disabled:-ms-input-placeholder {
   color: rgba(34, 35, 36, 0.3);
 }
 
@@ -1573,13 +1574,13 @@ a.box:active {
           justify-content: flex-start;
   line-height: 24px;
   padding-left: 8px;
-  padding-right: 8px;
   position: relative;
   vertical-align: top;
   cursor: pointer;
   display: block;
   outline: none;
-  padding-right: 36px;
+  padding-right: 25px;
+  margin-right: 5px;
 }
 
 .select select:hover {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <div class="columns">
       <div class="column is-half is-offset-one-quarter">
       <div class="container is-clearfix">
-        <p class="control">
+        <p class="control" id="initial-config">
           <span class="select is-pulled-left">
             <select value="_" id="difficulty" onChange="selectDifficulty();">
               <option disabled="disabled">Select difficulty...</option>
@@ -20,9 +20,21 @@
               <option value="very hard">Ultimaszyna (very hard)</option>
             </select>
           </span>
+          <span class="select is-pulled-left">
+            <select value="_" id="faction-select" onChange="selectDifficulty();">
+              <option disabled="disabled">Select faction...</option>
+              <option value="green">Albion</option>
+              <option value="yellow">Crimea</option>
+              <option value="blue">Nordic</option>
+              <option value="white">Polania</option>
+              <option value="red">Rusviet</option>
+              <option value="black">Saxony</option>
+              <option value="purple">Togawa</option>
+            </select>
+          </span>
         </p>
-        <a class="button is-danger is-pulled-right" onClick="resetGame();">Reset</a>
         <a id="start" class="button is-success is-pulled-right" onClick="startGame();">Start</a>
+        <a class="button is-danger is-pulled-right" onClick="resetGame();">Reset</a>
       </div>
       <div class="spacer-10"></div>
       <div class="container is-clearfix">
@@ -34,18 +46,20 @@
         <div class="spacer-40"></div>
         <div id="tracker" class="controls"></div>
         <div class="spacer-40"></div>
-        <div class="controls">
+        <div id="star-panel" class="controls">
           <a id="combatstar" class="button is-default" disabled="disabled" onClick="addCombatStar();">+1 Combat Star</a>
           <a id="powerstar" class="button is-default" disabled="disabled" onClick="addPowerStar();">+1 Power Star</a>
         </div>
       </div>
       <div class="container is-clearfix">
-        <p>
-          <div class="level">
-            <div class="is-pulled-left"><span id="phase"></span></div>
-            <div class="is-pulled-right"><span id="stars">&#9734; &#9734; &#9734; &#9734; &#9734; &#9734;</span></div>
-          </div>
-        </p>
+        <div id="faction-insignia">
+          <canvas id='insignia' class="faction-canvas" data-faction-color="red" height="30" width="30">
+          </canvas>
+        </div>
+        <div class="level">
+          <div class="is-pulled-left"><span id="phase"></span></div>
+          <div class="is-pulled-right"><span id="stars">&#9734; &#9734; &#9734; &#9734; &#9734; &#9734;</span></div>
+        </div>
       </div>
       <div class="container">
         <div id="normalCard">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
   <title>Scythe Automa - Online Simulator</title>
   <link rel="stylesheet" type="text/css" href="bulma.css">
   <link rel="stylesheet" type="text/css" href="style.css">
+  <style>
+  .centered-cardmeta {
+    float: none;
+    width: 100%;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    cursor: pointer;
+  }
+  </style>
 </head>
 <body>
   <section class="section">
@@ -34,7 +44,7 @@
           </span>
         </p>
         <a id="start" class="button is-success is-pulled-right" onClick="startGame();">Start</a>
-        <a class="button is-danger is-pulled-right" onClick="resetGame();">Reset</a>
+        <a class="button is-danger is-pulled-right" id='reset' onClick="resetGame();">Reset</a>
       </div>
       <div class="spacer-10"></div>
       <div class="container is-clearfix">
@@ -42,6 +52,7 @@
           <a id="playcard" class="button is-default" disabled="disabled" onClick="normalCard();">Play Card</a>
           <a id="playcombatcard" class="button is-default" disabled="disabled" onClick="combatCard();">Combat Card</a>
           <a id="checklastcard" class="button is-default" disabled="disabled" onClick="checkLastCard();">Previous Card</a>
+          <a id="showpresentcard" class="button is-default" style="display: none;">Current Card</a>
         </div>
         <div class="spacer-40"></div>
         <div id="tracker" class="controls"></div>
@@ -53,12 +64,25 @@
       </div>
       <div class="container is-clearfix">
         <div id="faction-insignia">
-          <canvas id='insignia' class="faction-canvas" data-faction-color="red" height="30" width="30">
+          <canvas id='insignia' class="faction-canvas" data-faction-color="red" height="48" width="48">
           </canvas>
         </div>
         <div class="level">
           <div class="is-pulled-left"><span id="phase"></span></div>
           <div class="is-pulled-right"><span id="stars">&#9734; &#9734; &#9734; &#9734; &#9734; &#9734;</span></div>
+        </div>
+      </div>
+      <div class="container is-clearfix cardmeta">
+        <div class="level">
+          <p>
+            <small class="is-pulled-left"><em><span id="deck-count">0</span>/<span id="card-count">0</span> cards left</em></small>
+            <small class='centered-cardmeta'>
+              <em><span id="turn-info"></span></em>
+            </small>
+          </p>
+          <p>
+            <small id='current-card-number' class="is-pulled-right"><em>Card #<span id="card-id">0</span></em></small>
+          </p>
         </div>
       </div>
       <div class="container">
@@ -89,19 +113,12 @@
           </article>
         </div>
       </div>
-      <div class="container">
-        <div class="level">
-          <p>
-            <small class="is-pulled-left"><em><span id="deck-count">0</span>/<span id="card-count">0</span> cards left</em></small>
-          </p>
-          <p>
-            <small class="is-pulled-right"><em>Card #<span id="card-id">0</span></em></small>
-          </p>
-        </div>
-      </div>
     </div>
   </section>
+  <script src="./jquery-3.3.1.slim.min.js"></script>
   <script src="./scythe-automa-cards.js"></script>
-  <script src="./scythe-automa.js"></script>
+  <script src="./scythe-automa.js"></script>  
+  <script src="./setup.js"></script>
+  <!-- <script src="./fenris.js"></script> -->
 </body>
 </html>

--- a/scythe-automa-cards.js
+++ b/scythe-automa-cards.js
@@ -1,22 +1,25 @@
-var profiles = [{ t: 'easy',   name: 'Autometta',
+var profiles = [
+{ t: 'easy', 
+  name: 'Autometta',
   rivers: 5,
   phase: 11,
-  grid: [0,0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,1,2,2]
-},{ t: 'normal',   name: 'Automa',
+  grid: [0,0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,1,2,2]},
+{ t: 'normal', 
+  name: 'Automa',
   rivers: 4,
   phase: 10,
-  grid: [0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,2,2]
-},{ t: 'hard',   name: 'Automaszyna',
+  grid: [0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,2,2]},
+{ t: 'hard', 
+  name: 'Automaszyna',
   rivers: 3,
   phase: 10,
-  grid: [0,0,0,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]
-},{
-  t: 'very hard',
+  grid: [0,0,0,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]},
+{ t: 'very hard',
   name: 'Ultimaszyna',
   rivers: 0,
   phase: 9,
-  grid: [1,1,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]
-}];
+  grid: [1,1,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]}
+];
 
 var cards = [
 {

--- a/scythe-automa-cards.js
+++ b/scythe-automa-cards.js
@@ -1,18 +1,12 @@
-var profiles = [{
-  t: 'easy',
-  name: 'Autometta',
+var profiles = [{ t: 'easy',   name: 'Autometta',
   rivers: 5,
   phase: 11,
   grid: [0,0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,1,2,2]
-},{
-  t: 'normal',
-  name: 'Automa',
+},{ t: 'normal',   name: 'Automa',
   rivers: 4,
   phase: 10,
   grid: [0,0,0,0,1,1,1,1,1,2,1,1,1,1,2,1,1,2,1,2,2,2]
-},{
-  t: 'hard',
-  name: 'Automaszyna',
+},{ t: 'hard',   name: 'Automaszyna',
   rivers: 3,
   phase: 10,
   grid: [0,0,0,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]
@@ -24,7 +18,8 @@ var profiles = [{
   grid: [1,1,1,1,1,1,1,1,2,1,1,2,1,2,1,2,2,2]
 }];
 
-var cards = [{
+var cards = [
+{
   id: 0,
   skip: false,
   star: true,
@@ -35,33 +30,18 @@ var cards = [{
   },
   actions: [{
     move: [
-      {
-        t: 'worker',
-        faction: 'blue'
-      },
-      {
-        t: 'facobj'
-      },
-      {
-        t: 'character'
-      }
+      { t: 'worker', faction: 'blue' },
+      { t: 'facobj' },
+      { t: 'character' }
     ],
-    gets: [{
-      t: 'power',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    }],
+    gets: [
+      { t: 'power',  q: 1},
+      { t: 'worker', q: 1} ],
     enlist: ['power']
   },{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'power',
-      q: 4
-    }],
+    move: [{ t: 'worker' }],
+    gets: [{ t: 'power', q: 4 }
+      ],
     enlist: ['power']
   }]
 },{
@@ -74,41 +54,23 @@ var cards = [{
     resources: 2
   },
   actions: [{
-    move: [{
-      faction: 'white',
-      t: 'facobj'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { faction: 'white', t: 'facobj' },
+      { t: 'worker' } ],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },       
+      { t: 'gold', q: 1} ],
     enlist: []
   },{
-    move: [{
-      faction: 'white',
-      t: 'facobj'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'powercard',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { faction: 'white', t: 'facobj' },
+      { t: 'worker' } ],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },   
+      { t: 'powercard',  q: 1 },   
+      { t: 'charormech', q: 1 } ],
     enlist: ['gold']
-  }]
+  }] 
 },{
   id: 2,
   skip: false,
@@ -118,27 +80,16 @@ var cards = [{
     cards: 0,
     resources: 0
   },
-  actions: [{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    }],
-    enlist: []
-  },{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'power',
-      q: 2
-    },{
-      t: 'worker',
-      q: 1
-    }],
-    enlist: ['popularity']
+  actions: [{ 
+    move: [ { t: 'worker' } ],
+    gets: [ { t: 'power', q: 3 } ],
+    enlist: [] 
+  },{ 
+    move: [ { t: 'worker' } ],
+    gets: [ 
+      { t: 'power',  q: 2 },
+      { t: 'worker', q: 1 } ],
+    enlist: ['popularity'] 
   }]
 },{
   id: 3,
@@ -149,35 +100,20 @@ var cards = [{
     cards: 1,
     resources: 0
   },
-  actions: [{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'powercard',
-	    q: 1,
-    },{
-      t: 'powercard'
-    }],
-    enlist: ['powercard']
-  },{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'gold',
-      q: 2
-    }],
-    enlist: ['power']
-  }]
+  actions: [{ 
+    move: [{ t: 'worker' }],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },   
+      { t: 'powercard', q: 1, },
+      { t: 'powercard' } ],
+    enlist: ['powercard'] 
+  },{ 
+    move: [{ t: 'worker' } ],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },   
+      { t: 'gold', q: 2 } ],
+    enlist: ['power'] }
+  ]
 },{
   id: 4,
   skip: false,
@@ -188,35 +124,19 @@ var cards = [{
     resources: 4
   },
   actions: [{
-    move: [{
-      faction: 'green',
-      t: 'facobj'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'purple',
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { faction: 'green', t: 'facobj' },
+      { t: 'worker' }],
+    gets: [
+      { faction: 'purple', t: 'charormech', q: 1 },
+      { t: 'worker', q: 1 },
+      { t: 'gold', q: 1 } ],
     enlist: ['gold']
   },{
-    move: [{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'power',
-      q: 4
-    },{
-      t: 'worker',
-      q: 1
-    }],
+    move: [{ t: 'mech' }],
+    gets: [
+      { t: 'power', q: 4 },
+      { t: 'worker', q: 1 } ],
     enlist: ['powercard']
   }]
 },{
@@ -229,29 +149,15 @@ var cards = [{
     resources: 0
   },
   actions: [{
-    move: [{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'power',
-      q: 2
-    }],
+    move: [{ t: 'worker' }],
+    gets: [{ t: 'power', q: 2 }],
     enlist: []
   },{
-    move: [{
-      t: 'mech'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'power',
-      q: 2
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [{ t: 'mech' }],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },
+      { t: 'power', q: 2 },
+      { t: 'charormech', q: 1 } ],
     enlist: ['power']
   }]
 },{
@@ -264,42 +170,21 @@ var cards = [{
     resources: 2
   },
   actions: [{
-    move: [{
-      faction: 'black',
-      t: 'attack',
-      o: 'charormech',
-      p: 5
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { faction: 'black', t: 'attack',o: 'charormech', p: 5 },
+      { t: 'worker' }],
+    gets: [
+      { t: 'worker', q: 1 },
+      { t: 'gold', q: 1 } ],
     enlist: ['popularity']
   },{
-    move: [{
-      faction: 'black',
-      t: 'attack',
-      o: 'charormech',
-      p: 5
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      faction: 'red',
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'powercard',
-      q: 1
-    }],
+    move: [
+      { faction: 'black', t: 'attack', o: 'charormech', p: 5 },
+      { t: 'mech' }],
+    gets: [
+      { faction: 'red', t: 'charormech', q: 1 },
+      { t: 'charormech', q: 1 },
+      { t: 'powercard', q: 1 } ],
     enlist: ['gold']
   }]
 },{
@@ -312,41 +197,22 @@ var cards = [{
     resources: 1
   },
   actions: [{
-    move: [{
-      faction: 'purple',
-      t: 'facobj'
-    },{
-      t: 'mech'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'red',
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { faction: 'purple', t: 'facobj' },
+      { t: 'mech' },
+      { t: 'worker' } ],
+    gets: [
+      { faction: 'red', t: 'charormech', q: 1 },
+      { t: 'charormech', q: 1 } ],
     enlist: []
   },{
-    move: [{
-      faction: 'purple',
-      type: 'facobj'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      faction: 'black',
-      t: 'power',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { faction: 'purple', type: 'facobj' },
+      { t: 'mech' }],
+    gets: [
+      { faction: 'black', t: 'power', q: 1 },
+      { t: 'gold', q: 1 },
+      { t: 'charormech', q: 1 } ],
     enlist: ['gold']
   }]
 },{
@@ -359,36 +225,21 @@ var cards = [{
     resources: 3
   },
   actions: [{
-    move: [{
-      faction: 'white',
-      t: 'facobj'
-    },{
-      t: 'mech'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { faction: 'white', t: 'facobj' },
+      { t: 'mech' },
+      { t: 'worker' }],
+    gets: [
+      { t: 'worker',     q: 1 },
+      { t: 'charormech', q: 1 }],
     enlist: ['popularity']
   },{
-    move: [{
-      faction: 'white',
-      t: 'facobj'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    },{
-      t: 'worker',
-      q: 1
-    }],
+    move: [
+      { faction: 'white', t: 'facobj' },
+      { t: 'mech' }],
+    gets: [
+      { t: 'power',  q: 3 },
+      { t: 'worker', q: 1 } ],
     enlist: ['popularity']
   }]
 },{
@@ -401,30 +252,18 @@ var cards = [{
     resources: 1
   },
   actions: [{
-    move: [{
-      t: 'mech'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'power',
-      q: 2
-    }],
+    move: [
+      { t: 'mech' },
+      { t: 'worker' }],
+    gets: [
+      { t: 'charormech', q: 1 },
+      { t: 'power',      q: 2 } ],
     enlist: []
   },{
-    move: [{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'gold',
-      q: 2
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [{ t: 'mech' }],
+    gets: [
+      { t: 'gold',       q: 2 },
+      { t: 'charormech', q: 1 }],
     enlist: []
   }]
 },{
@@ -437,41 +276,23 @@ var cards = [{
     resources: 0
   },
   actions: [{
-    move: [{
-      t: 'mech'
-    },{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      faction: 'red',
-      t: 'worker',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { t: 'mech' },
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { faction: 'red', t: 'worker', q: 1 },
+      { t: 'worker', q: 1 },
+      { t: 'gold',   q: 1 } ],
     enlist: []
   },{
-    move: [{
-      faction: 'blue',
-      t: 'worker'
-    },{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    },{
-      t: 'worker',
-      q: 1
-    }],
+    move: [
+      { faction: 'blue', t: 'worker' },
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { t: 'power',  q: 3 },
+      { t: 'worker', q: 1 }],
     enlist: ['powercard']
   }]
 },{
@@ -484,34 +305,19 @@ var cards = [{
     resources: 1
   },
   actions: [{
-    move: [{
-      faction: 'blue',
-      t: 'worker'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'power',
-      q: 4
-    }],
+    move: [
+      { faction: 'blue', t: 'worker' },
+      { t: 'mech' }],
+    gets: [{ t: 'power', q: 4 }],
     enlist: []
   },{
-    move: [{
-      faction: 'blue',
-      t: 'worker'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'powercard',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { faction: 'blue', t: 'worker' },
+      { t: 'mech' }],
+    gets: [
+      { t: 'powercard',  q: 1 },
+      { t: 'gold',       q: 1 },
+      { t: 'charormech', q: 1 } ],
     enlist: ['power']
   }]
 },{
@@ -524,39 +330,20 @@ var cards = [{
     resources: 0
   },
   actions: [{
-    move: [{
-      faction: 'black',
-      t: 'attack',
-      o: 'charormech',
-      p: 4
-    },{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { faction: 'black', t: 'attack', o: 'charormech', p: 4},
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [{ t: 'gold', q: 1 }],
     enlist: []
   },{
-    move: [{
-      faction: 'black',
-      t: 'attack',
-      o: 'charormech',
-      p: 5
-    },{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'powercard',
-      q: 1
-    },{
-      t: 'gold',
-      q: 2
-    }],
+    move: [
+      { faction: 'black', t: 'attack', o: 'charormech', p: 5 },
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { t: 'powercard', q: 1 },
+      { t: 'gold', q: 2 }],
     enlist: ['gold']
   }]
 },{
@@ -569,34 +356,19 @@ var cards = [{
     resources: 0
   },
   actions: [{
-    move: [{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'powercard',
-      q: 1
-    }],
+    move: [
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { t: 'worker',    q: 1 },
+      { t: 'powercard', q: 1 }],
     enlist: ['powercard']
   },{
-    move: [{
-      t: 'attack',
-      o: 'charormech',
-      p: 7
-    },{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    }],
+    move: [
+      { t: 'attack', o: 'charormech', p: 7},
+      { t: 'attack', o: 'worker' },
+      { t: 'mech' }],
+    gets: [{ t: 'power', q: 3 }],
     enlist: ['popularity']
   }]
 },{
@@ -609,40 +381,22 @@ var cards = [{
     resources: 2
   },
   actions: [{
-    move: [{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { t: 'power', q: 3 },
+      { t: 'gold', q: 1 }],
     enlist: ['gold']
   },{
-    move: [{
-      t: 'attack',
-      o: 'charormech',
-      p: 1
-    },{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { t: 'attack', o: 'charormech', p: 1},
+      { t: 'attack', o: 'worker' },
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },
+      { t: 'gold', q: 1 }],
     enlist: ['powercard']
   }]
 },{
@@ -655,38 +409,20 @@ var cards = [{
     resources: 4
   },
   actions: [{
-    move: [{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      t: 'charormech',
-      q: 1
-    }],
+    move: [
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [{ t: 'charormech', q: 1 }],
     enlist: []
   },{
-    move: [{
-      t: 'attack',
-      o: 'charormech',
-      p: 5
-    },{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'mech'
-    }],
-    gets: [{
-      faction: 'black',
-      t: 'power',
-      q: 1
-    },{
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { t: 'attack', o: 'charormech', p: 5},
+      { t: 'attack', o: 'worker' },
+      { t: 'mech' }],
+    gets: [
+      { faction: 'black', t: 'power', q: 1 },
+      { t: 'charormech', q: 1 },
+      { t: 'gold', q: 1 }],
     enlist: []
   }]
 },{
@@ -699,40 +435,20 @@ var cards = [{
     resources: 2
   },
   actions: [{
-    move: [{
-      t: 'attack',
-      o: 'charormech',
-      p: 6
-    },{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'gold',
-      q: 2
-    }],
+    move: [
+      { t: 'attack', o: 'charormech', p: 6 },
+      { t: 'attack', o: 'worker' },
+      { t: 'worker' }],
+    gets: [{ t: 'gold', q: 2 }],
     enlist: ['power']
   },{
-    move: [{
-      t: 'attack',
-      o: 'charormech',
-      p: 8
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      faction: 'yellow',
-      t: 'gold',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    }],
+    move: [
+      { t: 'attack', o: 'charormech', p: 8 },
+      { t: 'worker' }],
+    gets: [
+      { faction: 'yellow', t: 'gold', q: 1 },
+      { t: 'gold', q: 1 },
+      { t: 'worker', q: 1 }],
     enlist: ['popularity']
   }]
 },{
@@ -745,40 +461,22 @@ var cards = [{
     resources: 1
   },
   actions: [{
-    move: [{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      faction: 'green',
-      t: 'worker',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { faction: 'green', t: 'worker', q: 1 },
+      { t: 'worker', q: 1 },
+      { t: 'gold', q: 1 }],
     enlist: []
   },{
-    move: [{
-      t: 'facobj'
-    },{
-      t: 'character'
-    }],
-    gets: [{
-      faction: 'green',
-      t: 'charormech',
-      q: 1
-    },{
-      t: 'worker',
-      q: 1
-    },{
-      t: 'gold',
-      q: 2
-    }],
+    move: [
+      { t: 'facobj' },
+      { t: 'character' }],
+    gets: [
+      { faction: 'green', t: 'charormech', q: 1 },
+      { t: 'worker', q: 1 },
+      { t: 'gold', q: 2 }],
     enlist: []
   }]
 },{
@@ -791,34 +489,19 @@ var cards = [{
     resources: 1
   },
   actions: [{
-    move: [{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'worker',
-      q: 1
-    }],
+    move: [
+      { t: 'attack', o: 'worker' },
+      { t: 'worker' }],
+    gets: [{ t: 'worker', q: 1 }],
     enlist: []
   },{
-    move: [{
-      faction: 'green',
-      t: 'facobj'
-    },{
-      t: 'attack',
-      o: 'worker'
-    },{
-      t: 'worker'
-    }],
-    gets: [{
-      t: 'power',
-      q: 3
-    },{
-      t: 'gold',
-      q: 1
-    }],
+    move: [
+      { faction: 'green', t: 'facobj' },
+      { t: 'attack', o: 'worker' },
+      { t: 'worker' }],
+    gets: [
+      { t: 'power', q: 3 },
+      { t: 'gold', q: 1 }],
     enlist: ['powercard']
   }]
 }];

--- a/scythe-automa.js
+++ b/scythe-automa.js
@@ -229,7 +229,7 @@ var renderCanvas = function() {
 
 var renderCombat = function(card) {
   var htmlCombat = '<table class="table is-narrow"><thead><tr>';
-  var arr = ['0-7', '8-13', '14+', 'P', 'R'];
+  var arr = ['0-7', '8-13', '14+', '', ''];
   for (var i = 0; i < arr.length; i++) {
     htmlCombat += '<th>' + arr[i] + '</th>'
   }
@@ -239,8 +239,15 @@ var renderCombat = function(card) {
     for (var i = 0; i < 3; i++) {
       htmlCombat += '<td>' + cc.spend[i] + '</td>'
     }
-    htmlCombat += '<td>' + cc.cards + '</td>';
-    htmlCombat += '<td>' + cc.resources + '</td>';
+
+    htmlCombat += '<td>';
+    for(var i = 0; i < cc.cards; i++) { 
+      htmlCombat += fs.renderIcon('powercard','combat-card') }
+    htmlCombat += '</td><td>';
+
+    for(var i = 0; i < cc.resources; i++) { 
+      htmlCombat += fs.renderIcon('resource','combat-card') }
+    htmlCombat += '</td>';
   } else {
     for (var i = 0; i < 5; i++) {
       htmlCombat += '<td></td>';
@@ -251,6 +258,8 @@ var renderCombat = function(card) {
   document.getElementById('deck-count').innerHTML = deck.length;
   document.getElementById('card-count').innerHTML = cards.length;
   document.getElementById('card-id').innerHTML = card.id + 1;
+
+  renderCanvas();
 };
 
 var findProfile = function(profiles, type) {
@@ -395,14 +404,13 @@ var normalCard = function() {
 
 var combatCard = function() {
   var card = takeCard();
-  renderNormal(card);
   renderCombat(card);
   renderIsCombat(true);
   discards.battle.push(card);
 };
 
 var checkLastCard = function() {
-  var card = lastCard();
+  var card  = lastCard();
   var phase = 0;
   for (var i = 0; i < profile.grid.length; i++) {
     if (profile.grid[i] < 2) continue;

--- a/scythe-automa.js
+++ b/scythe-automa.js
@@ -5,17 +5,16 @@ var ICON_SD = 96;
 var FACTION_DD = 30;
 var FACTION_SD = 100;
 
-var tracker, stars, combatstars, powerstars, phase, deck, discards;
+var tracker, stars, combatstars, powerstars, phase, deck, discards, faction;
 
 var iconindex = [
-  'move', 'factory', 'turn', 'phase2', 'isolated', 'phase1', 'star', 'attack', 'ignore',
-  'popularity', 'gold', 'power', 'encounter', 'powercard', 'resource', 'enlist', 'mech',
-  'worker', 'character', 'charormech', 'facobj'
+  'move',     'factory',   'turn',    'phase2',    'isolated','phase1',
+  'star',     'attack',    'ignore',  'popularity','gold',    'power',
+  'encounter','powercard', 'resource','enlist',    'mech',    'worker',
+  'character','charormech','facobj'
 ];
 
-var factionindex = [
-  'black', 'blue', 'red', 'yellow', 'white', 'purple', 'green'
-];
+var factionindex = [ 'black','blue','red','yellow','white','purple','green' ];
 
 var fs = {
   dupe: function(obj) {
@@ -32,14 +31,17 @@ var fs = {
   },
   renderFactionOption: function(f, t) {
     var html = fs.renderAnnotation('(');
-    html += '<canvas class="faction-canvas" data-faction-color="' + f + '" height="'+FACTION_DD+'" width="'+FACTION_DD+'"></canvas>';
+    html += '<canvas class="faction-canvas" data-faction-color="' + f 
+    html += '" height="'+FACTION_DD+'" width="'+FACTION_DD+'"></canvas>';
     html += t;
     html += fs.renderAnnotation(')');
     return html;
   },
   renderIcon: function(type, addClass) {
     var cl = typeof addClass == 'undefined' ? '' : addClass;
-    return '<canvas class="icon-canvas ' + cl + '"  data-icon-type="' + type + '" height="'+ICON_DD+'" width="'+ICON_DD+'"></canvas>';
+    return '<canvas class="icon-canvas ' 
+      + cl + '"  data-icon-type="' + type + '" height="' + ICON_DD + '" width="'
+      + ICON_DD + '"></canvas>';
   }
 };
 
@@ -322,7 +324,10 @@ var resetGame = function() {
   discards = {
     main: [],
     battle: []
-  };
+  };  
+  faction = document.getElementById('faction-select').value;
+  document.getElementById('insignia').setAttribute('data-faction-color',faction);
+
   var difficulty = document.getElementById('difficulty').value;
   profile = findProfile(profiles, difficulty);
   renderTracker();

--- a/scythe-automa.js
+++ b/scythe-automa.js
@@ -14,7 +14,8 @@ var iconindex = [
   'character','charormech','facobj'
 ];
 
-var factionindex = [ 'black','blue','red','yellow','white','purple','green' ];
+var factionindex   = [ 'black','blue','red','yellow','white','purple','green' ];
+var factionsprites = 'assets/factions-96x96.png';
 
 var fs = {
   dupe: function(obj) {
@@ -27,7 +28,10 @@ var fs = {
     return item;
   },
   renderAnnotation: function(t) {
-    return '<span class="card-annotation">'+t+'</span>';
+    var annotationClass = t.match(/\s*[\(\)]\s*/) !== null 
+      ? 'card-annotation parens'
+      : 'card-annotation';
+    return '<span class="'+annotationClass+'">'+t+'</span>';
   },
   renderFactionOption: function(f, t) {
     var html = fs.renderAnnotation('(');
@@ -92,6 +96,10 @@ var renderGetsAction = function(card, phase, index) {
   var pac = card.actions[phase].gets[index];
   var html = ""
   for (var i = 0; i < pac.q; i++) {
+    if (pac.q > 4){ 
+      html += ' <span class="card-annotation">'+pac.q;
+      html += 'x</span>'+fs.renderIcon(pac.t); 
+      break}
     html += fs.renderIcon(pac.t);
   }
   if (pac.faction)
@@ -208,7 +216,13 @@ var renderCanvas = function() {
 
   var factions = document.getElementsByClassName('faction-canvas');
   for (var i = 0; i < factions.length; i++) {
-    doDraw(factions[i], 'assets/factions-96x96.png', factionindex, 'data-faction-color', FACTION_SD, FACTION_DD);
+    factions[i].id == 'insignia' ? (dd = 48) : (dd = FACTION_DD);
+    doDraw(factions[i],
+      factionsprites,
+      factionindex,
+      'data-faction-color',
+      FACTION_SD, 
+      dd);
   }
 
 };
@@ -324,7 +338,7 @@ var resetGame = function() {
   discards = {
     main: [],
     battle: []
-  };  
+  };
   faction = document.getElementById('faction-select').value;
   document.getElementById('insignia').setAttribute('data-faction-color',faction);
 

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,67 @@
+var turns      = [];
+
+var findCard = function(cards,cardNumber){
+  return cards.find(function(card) {
+    return card.id == cardNumber - 1;
+  });
+}
+
+var roundTracker = function(){
+  var roundCard = $('span#card-id').text()+'';
+  $('#last-played-card').text(roundCard);
+  $('#current-card-number').show();
+  $('#ccard div.message-header').text('Combat Card');
+  turns.push(roundCard);
+  var msg = 'turn '+(turns.length)+', card #'+roundCard;
+  if( findCard(cards,roundCard).star ) msg += ', advancing track';
+  console.log( msg );
+  if (phase == 1) console.log( turns );
+  $('#turn-info').text('Turn '+turns.length);
+  $('.centered-cardmeta').attr(
+    'title',
+    'Last 5 cards (non-combat): '+turns.slice(-6).reverse().join(', '));
+
+  var decklist = '';
+  for(var card of deck){
+    decklist += (card.id + 1) + ' ';
+  }
+  console.log(decklist);
+}
+
+// turn tracker
+$('#playcombatcard').click(function(){
+  var combatCardNumber = discards.battle[discards.battle.length-1].id + 1;
+  $('#ccard div.message-header').text('Combat Card #'+combatCardNumber);
+});
+$('#playcard').click( roundTracker );
+$('#checklastcard').click( function(){
+  $('#last-played-card').text($('span#card-id').text()+'');  
+  $('#ccard div.message-header').text('Combat Card');
+  $('#checklastcard').hide();
+  $('#showpresentcard').show();
+});
+
+$('#showpresentcard').hide();
+$('#showpresentcard').click( function(){
+  if ( ! discards.main.length ){ return false; }
+  var card = discards.main[discards.main.length - 1];
+  renderNormal(card,phase);
+  renderCombat(card);
+  renderIsCombat(false);
+  renderCardPhase(phase);
+  $('#last-played-card').text($('span#card-id').text()+'');
+  $('#ccard div.message-header').text('Combat Card');
+  $('#checklastcard').removeAttr('disabled').show();
+  $('#showpresentcard').hide();
+});
+// reset
+$('#reset').click(function(){ 
+  turns.length = 0; $('#tracker').attr('title','');
+  $('#current-card-number').hide();
+  $('span#card-id').text('');
+  $('#showpresentcard').hide();
+  $('#checklastcard').show().attr('disabled','disabled');
+});
+
+$('#current-card-number').hide().append('<span id="last-played-card"></span>');
+$('span#card-id').hide();

--- a/style.css
+++ b/style.css
@@ -4,16 +4,12 @@ html .container, section {
 }
 section {
   padding: 20px !important;
+  height: 100%;
 }
-.spacer-40 {
-  height: 40px;
-}
-.spacer-20 {
-  height: 20px;
-}
-.spacer-10 {
-  height: 10px;
-}
+.spacer-40 { height: 40px; }
+.spacer-20 { height: 20px; }
+.spacer-10 { height: 10px; }
+
 #tracker {
   margin: -25px;
 }
@@ -32,51 +28,54 @@ section {
   font-size: 20px;
   color: #444;
 }
-.acard {
-  height: 90px;
+#faction-insignia {
+  text-align: center;
+  margin: 5px 0 -25px;
 }
-.ccard {
-  height: 95px;
-}
-.acard.message {
-  margin-bottom: 0 !important;
-}
-.acard .message-header {
-  height: 30px;
-}
+
+.acard { height: 90px; }
+.acard.message { margin-bottom: 0 !important; }
+.acard .message-header { height: 30px; }
 .acard .message-body {
   height: 60px;
   text-align: center;
 }
+
+.ccard { height: 95px; }
+.ccard table { background-color: transparent; }
+#ccard[data-is-combat='true'] { border: 2px solid red; }
 .ccard .message-body {
   height: 60px;
   padding: 0;
 }
-.ccard table {
-  background-color: transparent;
-}
-#ccard[data-is-combat='true'] {
-  border: 2px solid red;
-}
-.message.is-success .message-header {
-  background-color: #4A692E;
-}
-.message.is-danger .message-header {
-  background-color: #8D3B1D;
-}
+.message.is-success .message-header { background-color: #4A692E; }
+.message.is-danger  .message-header { background-color: #8D3B1D; }
 .message-body {
   color: #444 !important;
   line-height: 32px;
 }
-.container {
-  max-width: 505px !important;
-}
+.container { max-width: 505px !important; }
 
 .card-annotation {
   font-size: 32px;
   vertical-align: top;
   font-weight: bold;
 }
-.or-slash {
-  margin-right: 2px;
+.or-slash { margin-right: 2px; }
+
+@media screen and (max-width: 550px) {
+  .select, .select select { width: 100% }
+  .select { margin-bottom: 5px }
+  .button.is-default { 
+    width: 100%; 
+    margin: 0 0 5px 0; }
+  .button.is-pulled-right, 
+  #star-panel .button { 
+    width: 49% 
+  }
+  .container .button:first-of-type {
+    float: left;
+    margin-left: 0;
+  }
+
 }

--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ section {
   text-align: center;
   margin: 5px 0 -25px;
 }
-
+.cardmeta { font-style: italic; }
 .acard { height: 90px; }
 .acard.message { margin-bottom: 0 !important; }
 .acard .message-header { height: 30px; }
@@ -47,6 +47,15 @@ section {
 .ccard .message-body {
   height: 60px;
   padding: 0;
+}
+.ccard .icon-canvas.combat-card {
+  width: 18px;
+  height: 18px;
+}
+#combat-card-actions table td, 
+#combat-card-actions table th{
+  width: 20%;
+  text-align: center;
 }
 .message.is-success .message-header { background-color: #4A692E; }
 .message.is-danger  .message-header { background-color: #8D3B1D; }

--- a/style.css
+++ b/style.css
@@ -58,8 +58,12 @@ section {
 
 .card-annotation {
   font-size: 32px;
+  line-height: 32px;
   vertical-align: top;
   font-weight: bold;
+}
+.card-annotation.parens {
+  line-height: 26px;
 }
 .or-slash { margin-right: 2px; }
 


### PR DESCRIPTION
As you might have gathered, faction selection is now possible.

I also updated **many** things that bothered me while I was playing through Rise of Fenris vs multiple Automa.

- There's now a **turn tracker**, so you can see what turn you're on, and mouse-over shows a list of the last 5 cards (all of them are in console)
- Previous Card now **toggles** with Current Card, so you can flip back and forth.
- Combat cards **do not** affect the main card actions (I'd often forget what was supposed to happen after combat otherwise)
- Combat card Resource + Powercard info now represented with icons

Lastly, one of the biggest changes was improving the UI in narrow windows, as I tended to have one open for each Automa:

![image](https://user-images.githubusercontent.com/487308/48811930-c9f86d00-ece4-11e8-98a9-1bbef05758b6.png)